### PR TITLE
feat: Add jinja2-style support. Add button to print full yaml templat…

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -4,6 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as path from 'path';
+import * as fs from 'fs';
 import { workspace, ExtensionContext } from 'vscode';
 import * as vscode from 'vscode'
 import {
@@ -151,6 +152,74 @@ export function activate(context: ExtensionContext) {
 			vscode.window.showErrorMessage(`Error: ${error.message}`);
 		}
 	});
+
+	const loadJSONContextFile = (): Record<string, any> => {
+		const workspaceFolders = vscode.workspace.workspaceFolders;
+		if (!workspaceFolders) {
+			return {};
+		}
+	
+		const contextFilePath = path.join(workspaceFolders[0].uri.fsPath,"context.json");
+	
+		if (!fs.existsSync(contextFilePath)) {
+			return {};
+		}
+	
+		try {
+		  	const data = fs.readFileSync(contextFilePath, "utf8");
+		  	return JSON.parse(data);
+		} catch (error) {
+		  	console.error("Error reading context.json:", error);
+		  	vscode.window.showErrorMessage("Error reading context.json: " + error.message);
+		  	return {};
+		}
+	};
+	
+	const replaceVariableCommand = vscode.commands.registerCommand("extension.replaceVariable", async () => {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+			vscode.window.showErrorMessage("No active editor found.");
+			return;
+		}
+		const text = editor.document.getText();
+		const context = loadJSONContextFile();
+	
+		if (!text) {
+			vscode.window.showErrorMessage("No text in file.");
+			return;
+		}
+	
+		await vscode.window.withProgress({
+			location: vscode.ProgressLocation.Notification,
+			title: "Replacing Variable",
+			cancellable: false,
+		}, async () => {
+			try {
+				const response = await client.sendRequest<{
+					success: boolean;
+				  	modifiedText?: string;
+				  	error?: string;
+				}>("yaml.replaceVariable", {
+				  	uri: editor.document.uri.toString(),
+				  	text: text,
+				  	context: context,
+				});
+
+				if (response.success && response.modifiedText) {
+				  	console.log("🔁 Full replaced YAML content:\n", response.modifiedText);
+				  	vscode.window.showInformationMessage("Full YAML replacement logged to console.");
+				} else if (response.error) {
+				  	console.error("Error in response:", response.error);
+				  	vscode.window.showErrorMessage("Error replacing variable: " + response.error);
+				} else {
+				  	vscode.window.showWarningMessage("No replacement text returned.");
+				}
+			} catch (error) {
+				vscode.window.showErrorMessage("Error replacing variable: " + error.message);
+			}
+		});
+	});
+
 	console.log("Extension activating...");
 	const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 1000);
     statusBarItem.text = '$(sparkle) Get LLM Feedback';
@@ -171,6 +240,15 @@ export function activate(context: ExtensionContext) {
 	context.subscriptions.push(
 		client,feedbackCommand, statusBarItem
 	);
+
+	const replaceVariableStatusBarItem = vscode.window.createStatusBarItem(
+		vscode.StatusBarAlignment.Right, 
+		2000
+	);
+	replaceVariableStatusBarItem.text = "$(sparkle) Replace Variable";
+	replaceVariableStatusBarItem.command = "extension.replaceVariable";
+	replaceVariableStatusBarItem.show();
+	context.subscriptions.push(replaceVariableStatusBarItem);
 
 	vscode.commands.executeCommand('setContext', 'hasSelection', true);
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -285,6 +285,85 @@ connection.onRequest('llm-schema.extractKeywords', async (params: { schema: any,
 	}
   });
 
+  const resolveExpression = (expr: string, vars: Record<string, any>): any => {
+	const trimmedExpr = expr.trim();
+	const parts = trimmedExpr.split(/[.\[\]]+/).filter(Boolean);
+	let result: any = undefined;
+  
+	const varName = parts[0];
+	if (!(varName in vars)) {
+		return undefined;
+	}
+  
+	result = vars[varName];
+  
+	for (let i = 1; i < parts.length; i++) {
+	  	const part = parts[i];
+  
+	  	const index = !isNaN(Number(part)) ? Number(part) : part;
+  
+	  	if (result === null || result === undefined) {
+			return undefined;
+	  	}
+  
+	  	result = result[index];
+  
+	  	if (result === undefined) {
+			return undefined;
+	  	}
+	}
+  
+	return result;
+};
+  
+const replacePlaceholders = (obj: any, vars: Record<string, any>): any => {
+	if (typeof obj === "string") {
+	  	return obj.replace(/\${(.*?)}/g, (match, expr) => {
+			const value = resolveExpression(expr, vars);
+			if (value === undefined) {
+		  		throw new Error(`Variable "${expr}" is not defined in context.`);
+			}
+			return value;
+	  });
+	} else if (typeof obj === "object" && obj !== null && !Array.isArray(obj)) {
+	  	for (const key in obj) {
+			if (Object.prototype.hasOwnProperty.call(obj, key)) {
+		  		obj[key] = replacePlaceholders(obj[key], vars);
+			}
+	  	}
+	} else if (Array.isArray(obj)) {
+	  	for (let i = 0; i < obj.length; i++) {
+			obj[i] = replacePlaceholders(obj[i], vars);
+	  	}
+	}
+	return obj;
+};
+  
+connection.onRequest("yaml.replaceVariable", async (params: { uri: string; context: any; text: string }) => {
+	const doc = documents.get(params.uri);
+	if (!doc) {
+		return { success: false, error: "Document not found" };
+	}
+	try {
+		const contextData = params.context;
+		const yamlData = parse(params.text);
+		// Replace variables in the text using the context data
+		const replacedData = replacePlaceholders(yamlData, contextData);
+		connection.console.log(JSON.stringify(replacedData, null, 2));
+		// Convert the modified YAML object back to a string
+		const yamlString = stringify(replacedData);
+		connection.console.log(yamlString);
+		// Send the modified YAML string back to the client
+		return {
+		  	success: true,
+		  	modifiedText: yamlString,
+		};
+	} catch (error) {
+		connection.console.error("Error processing YAML: " + error);
+		return { success: false, error: "Error processing YAML" };
+	}
+});
+
 connection.onInitialized(() => {
 	if (hasConfigurationCapability) {
 		// Register for all configuration changes.


### PR DESCRIPTION
This pull request introduces functionality to replace placeholders in YAML files using a context defined in a `context.json` file. It includes updates to both the client-side extension and the server-side logic. Key changes include adding a new command, updating the status bar, and implementing placeholder resolution and replacement logic.

### Client-Side Changes:
* **New Command for Replacing Variables**: Added the `replaceVariableCommand` to the client extension, which reads a `context.json` file from the workspace, sends the YAML content and context to the server, and handles the server's response.
* **Status Bar Update**: Introduced a new status bar item labeled "Replace Variable" that triggers the `replaceVariableCommand`.

### Server-Side Changes:
* **Variable Resolution Logic**: Implemented `resolveExpression` and `replacePlaceholders` functions to dynamically replace placeholders in YAML content using the provided context.
* **New Request Handler**: Added a `yaml.replaceVariable` request handler to process the YAML content, replace placeholders, and return the modified content to the client.

### Miscellaneous:
* **Dependency Update**: Imported the `fs` module in `client/src/extension.ts` to handle file operations.