### PR TITLE
Include - Feature to map path files to static YAML file contents

### DIFF
--- a/server/src/include.ts
+++ b/server/src/include.ts
@@ -1,0 +1,73 @@
+import * as fs from 'fs';
+import * as url from 'url';
+import * as path from 'path';
+import { parse } from 'yaml';
+
+export function isIncludeDirective(node: any): node is { include: string } {
+    return (
+        typeof node === 'object' &&
+        node !== null &&
+        !Array.isArray(node) &&
+        Object.keys(node).length === 1 &&
+        Object.prototype.hasOwnProperty.call(node, 'include') &&
+        typeof node['include'] === 'string'
+    );
+}
+
+export function validateStaticContent(node: any) {
+    if (typeof node === 'string') {
+        if (node.includes('${')) {
+            throw new Error(`Variable placeholder found: ${node}`);
+        }
+        return;
+    }
+    if (node === null || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+        node.forEach(item => validateStaticContent(item));
+    } else if (isIncludeDirective(node)) {
+        throw new Error(`Include directive found: ${node.include}`);
+    } else {
+        for (const key in node) {
+            if (Object.prototype.hasOwnProperty.call(node, key)) {
+                validateStaticContent(node[key]);
+            }
+        }
+    }
+}
+
+export function loadAndValidateIncludedContent(
+    filepath: string,
+    baseDir: string
+): any {
+    const fullPath = path.resolve(url.fileURLToPath(baseDir), filepath);
+    const fileExtension = path.extname(fullPath).toLowerCase();
+    const fileContent = fs.readFileSync(fullPath, 'utf8');
+    if (fileExtension === '.yaml') {
+        const parsedContent = parse(fileContent);
+        validateStaticContent(parsedContent);
+        return parsedContent;
+    } else {
+        return null;
+    }
+}
+
+export function processIncludes(
+    node: any,
+    baseDir: string
+): any {
+    if (node === null || typeof node !== 'object') return node;
+    if (Array.isArray(node)) {
+        return node.map(item => processIncludes(item, baseDir));
+    }
+    if (isIncludeDirective(node)) {
+        const filepath = node.include;
+        return loadAndValidateIncludedContent(filepath, baseDir);
+    }
+    const processedObject: any = {};
+    for (const key in node) {
+        if (Object.prototype.hasOwnProperty.call(node, key)) {
+            processedObject[key] = processIncludes(node[key], baseDir);
+        }
+    }
+    return processedObject;
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -304,9 +304,11 @@ connection.onRequest("yaml.replaceVariable", async (params: { uri: string; text:
 		const yamlData = parse(params.text);
 		// Replace variables in the text using the context data
 		const replacedData = replacePlaceholders(yamlData, loadedVariables);
+
+		const yamlImported = processIncludes(replacedData, path.dirname(doc.uri));
 		//connection.console.log(JSON.stringify(replacedData, null, 2));
 		// Convert the modified YAML object back to a string
-		const yamlString = stringify(replacedData);
+		const yamlString = stringify(yamlImported);
 		connection.console.log(yamlString);
 		// Send the modified YAML string back to the client
 		return {
@@ -355,6 +357,92 @@ connection.onInitialized( async () => {
 		
 	}
 });
+
+function isIncludeDirective(node: any): node is { include: string } {
+	return (
+        typeof node === 'object' &&
+        node !== null &&
+        !Array.isArray(node) && // Ensure it's a plain object, not an array treated as an object
+        Object.keys(node).length === 1 &&
+        Object.prototype.hasOwnProperty.call(node, 'include') &&
+        typeof node['include'] === 'string'
+    );
+}
+
+function validateStaticContent(node: any) {
+	if (typeof node === 'string') {
+		if (node.includes('${')) {
+			throw new Error(`Variable placeholder found: ${node}`);
+		}
+		return;
+	}
+
+	if (node === null || typeof node !== 'object') {
+		return;
+	}
+
+	if (Array.isArray(node)) {
+		node.forEach(item => validateStaticContent(item));
+	} else if (isIncludeDirective(node)) {
+		throw new Error(`Include directive found: ${node.include}`);
+	} else {
+		for (const key in node) {
+			if (Object.prototype.hasOwnProperty.call(node, key)) {
+				validateStaticContent(node[key]);
+			}
+		}
+	}
+}
+
+function loadAndValidateIncludedContent(filepath: string, baseDir: string): any {
+	connection.console.log(`Loading included file: ${filepath}`);
+	connection.console.log(`Base directory: ${baseDir}`);
+
+	const fullPath = path.resolve(url.fileURLToPath(baseDir), filepath);
+	connection.console.log(`Full path: ${fullPath}`);
+	const fileExtension = path.extname(fullPath).toLowerCase();
+	try {
+		const fileContent = fs.readFileSync(fullPath, 'utf8');
+		if (fileExtension === '.yaml') { // TODO: Support markdown
+			const parsedContent = parse(fileContent);
+			validateStaticContent(parsedContent);
+			return parsedContent
+		} else {
+			return null;
+		}
+ 	} catch (error) {
+		connection.console.error(`Error loading included file: ${error}`);
+		connection.window.showErrorMessage(`Error loading included file: ${error}`);
+		return null;
+	}
+}
+
+function processIncludes(node:any, baseDir: string): any {
+	if (node === null || typeof node !== 'object') {
+		return node;
+	}
+
+	if (Array.isArray(node)) {
+		return node.map(item => processIncludes(item, baseDir));
+	}
+
+	if (isIncludeDirective(node)) {
+		const filepath = node.include;
+		return loadAndValidateIncludedContent(filepath, baseDir);
+	}
+
+	const processedObject: any = {};
+	for (const key in node) {
+		if (Object.prototype.hasOwnProperty.call(node, key)) {
+			processedObject[key] = processIncludes(node[key], baseDir);
+		}
+	}
+
+	connection.console.log(`Processed includes for key: ${baseDir}}`);
+
+	return processedObject;
+}
+
 
 // The example settings
 interface ExampleSettings {

--- a/server/tsconfig.tsbuildinfo
+++ b/server/tsconfig.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./src/errorhandler.ts","./src/logger.ts","./src/server.ts","./src/expressions/index.ts","./src/expressions/resolve.ts","./src/expressions/utils.ts"],"version":"5.8.2"}
+{"root":["./src/errorhandler.ts","./src/include.ts","./src/logger.ts","./src/server.ts","./src/expressions/index.ts","./src/expressions/resolve.ts","./src/expressions/utils.ts"],"version":"5.8.2"}


### PR DESCRIPTION
### New functionality for YAML include directives:

* `server/src/include.ts`: Introduced a new module with functions to validate static content, handle include directives, and recursively process YAML nodes for includes. This ensures that included content is validated and integrated seamlessly.

### Integration into YAML processing:

* `server/src/server.ts`: Added the `processIncludes` function to the YAML variable replacement workflow. This processes and validates included content before converting the YAML back to a string.